### PR TITLE
Website touchups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The site is composed of two repositories:
 * [cncf/sig-contributor-strategy]: Contains the website infrastructure, and
   pages under the /maintainers section of the site.
 
-[Contributing Guide]: https://contribute.cncf.io/about/contributing/
+[Contributing Guide]: https://cncf-contribute.netlify.app/about/contributing/
 [cncf/sig-contributor-strategy]: https://github.com/cncf/sig-contributor-strategy/
 
 ## Netlify Deployments

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Welcome! Are you interested in contributing to one of CNCF hosted projects? This
 repository contains information and guidelines about contributions to CNCF
 projects.
 
-<p align="center"><a href="https://contribute.cncf.io/contributors/">Contribution Guides to the CNCF Ecosystem</a></p>
+<p align="center"><a href="https://cncf-contribute.netlify.app/contributors/">Contribution Guides to the CNCF Ecosystem</a></p>
 
 We have recently transitioned from having people use the markdown files in this
 repository directly to rendering them at the website above. See our
 [Contributing Guide][contributing] for details on how to contribute to our
 website.
 
-[contributing]: https://contribute.cncf.io/about/contributing
+[contributing]: https://cncf-contribute.netlify.app/about/contributing

--- a/build/deploy-redirect.html
+++ b/build/deploy-redirect.html
@@ -1,8 +1,8 @@
 <html>
 <head>
-    <meta http-equiv="refresh" content="time; URL=https://contribute.cncf.io" />
+    <meta http-equiv="refresh" content="time; URL=https://cncf-contribute.netlify.app" />
 </head>
 <body>
-    <p>The site has been deployed to <a href="https://contribute.cncf.io">contribute.cncf.io</a></p>
+    <p>The site has been deployed to <a href="https://cncf-contribute.netlify.app">contribute.cncf.io</a></p>
 </body>
 </html>

--- a/magefile.go
+++ b/magefile.go
@@ -22,7 +22,7 @@ var (
 )
 
 const (
-	webhook = "https://api.netlify.com/build_hooks/6005c2758a2bba09b6563667"
+	webhook = "https://api.netlify.com/build_hooks/6077044c670d3a4579bf1f99"
 )
 
 // Ensure Mage is installed and on the PATH.


### PR DESCRIPTION
* Trigger a build of the site on push
  Update the webhook URL now that the site is on the master branch (previously it was on main).
* Update links to point to temporary netlify URL
  Until we update the DNS for contribute.cncf.io, the current links will not work (or may point to a page on GitHub) because it is currently being used to redirect to this repository. This is a temporary change until the DNS is updated, then we can go back and change these URLs to point to contribute.cncf.io again.