### PR TITLE
Add probot settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,31 @@
+repository:
+  # See https://developer.github.com/v3/repos/#edit for all available settings.
+
+  # The name of the repository. Changing this will rename the repository
+  name: contribute
+
+  # A short description of the repository that will show up on GitHub
+  description: 🙋🏿‍♀️🙋🏽‍♂️🙋🏻‍♀️Contribution guide to the CNCF ecosystem
+
+  # A URL with more information about the repository
+  homepage: https://contribute.cncf.io
+
+  # Collaborators: give specific users access to this repository.
+collaborators:
+  # Admins
+  - username: amye
+    permission: admin
+
+  - username: idvoretskyi
+    permission: admin
+
+  - username: caniszczyk
+    permission: admin
+
+  - username: mrbobbytables
+    permission: push
+
+    # Contributors
+    # all permissions except admin
+  - username: carolynvs
+    permission: push


### PR DESCRIPTION
Add the probot file and define admins/reviewers.

I cannot see the current repository permissions, so I **guessed** based on who I have seen merging pull requests lately. If someone with write access could check the current permissions and provide a screenshot or list of names/roles, that would be great!