### PR TITLE
Add tinkerbell to sandbox projects

### DIFF
--- a/content/contributors/projects/_index.md
+++ b/content/contributors/projects/_index.md
@@ -517,6 +517,18 @@ Sandbox Projects
 -	**Contributor Guide:** [Litmus-contributor-guide](https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md)
 -	**Chat:** [Litmus Slack](https://slack.litmuschaos.io)
 -	**License:** [Apache 2.0](apache-license)
+
+### Tinkerbell
+
+*"Tinkerbell is a bare metal provisioning engine. Tinkerbell standardizes infrastructure and application management using the same API-centric, declarative configuration and automation approach pioneered by the Kubernetes community."* - [Tinkerbell](https://tinkerbell.org/)
+
+-	**Project Repository:** https://github.com/tinkerbell
+-	**Contributor Guide:** [tinkerbell/tink/CONTRIBUTING](https://github.com/tinkerbell/tink/blob/master/CONTRIBUTING.md)
+-	**Chat:** Slack: `#tinkerbell` in [slack.cncf.io](https://app.slack.com/client/T08PSQ7BQ/C01SRB41GMT)
+-	**Developer List/Forum:** [Tinkerbell Contributors Mailing List](https://groups.google.com/g/tinkerbell-contributors?pli=1)
+-	**License:** [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)
+-	**Legal Requirements:** [DCO](https://developercertificate.org/)
+
 ---
 
 Archived Projects


### PR DESCRIPTION
The PR adds [Tinkerbell](https://tinkerbell.org/) to the CNCF sandbox projects list.