### PR TITLE
Fix netlify deploy preview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,15 @@ The site is composed of two repositories:
 
 * cncf/contribute: This repository contains the pages under the /contributors
   section of the site.
-* [cncf/sig-contributor-strategy]: Contains the website infrastructure, and
+* [cncf/tag-contributor-strategy]: Contains the website infrastructure, and
   pages under the /maintainers section of the site.
 
 [Contributing Guide]: https://cncf-contribute.netlify.app/about/contributing/
-[cncf/sig-contributor-strategy]: https://github.com/cncf/sig-contributor-strategy/
+[cncf/tag-contributor-strategy]: https://github.com/cncf/sig-contributor-strategy/
 
 ## Netlify Deployments
 
-The main website is in another repository, [cncf/sig-contributor-strategy]. When
+The main website is in another repository, [cncf/tag-contributor-strategy]. When
 a pull request is created for this repository, Netlify clones the main repo and
 builds the website using the content from this repository. A preview of the
 website is available in the GitHub pull request.

--- a/magefile.go
+++ b/magefile.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	prodBranch = "website"
+	prodBranch = "main"
 )
 
 const (
@@ -81,10 +81,10 @@ func triggerNetlifyDeployment() error {
 // DeployPreview builds the entire website for a preview.
 func DeployPreview() error {
 	pwd, _ := os.Getwd()
-	websiteDir := filepath.Join(filepath.Dir(pwd), "sig-contributor-strategy")
+	websiteDir := filepath.Join(filepath.Dir(pwd), "tag-contributor-strategy")
 
 	if _, err := os.Stat(websiteDir); os.IsNotExist(err) {
-		err := shx.RunV("git", "clone", "-b", prodBranch, "--recurse-submodules", "https://github.com/cncf/sig-contributor-strategy.git", websiteDir)
+		err := shx.RunV("git", "clone", "-b", prodBranch, "--recurse-submodules", "https://github.com/cncf/tag-contributor-strategy.git", websiteDir)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* The repository has been renamed from SIG to TAG
* The default branch for TAG Contributor Strategy is now "main"

