### PR TITLE
Fix broken-link

### DIFF
--- a/content/contributors/projects/_index.md
+++ b/content/contributors/projects/_index.md
@@ -325,7 +325,7 @@ CloudEvents Specification
 *"Open source Kubernetes native workflows, events, CI and CD"* - [https://argoproj.github.io/ ][$Argo overview]
 
 -	**Project Repository:** https://github.com/argoproj/
--	**Contributor Guide:** [argo/community/](https://github.com/argoproj/community-contrib-docs/blob/3b76affa356dbc3160b31f9a96ac81dfa49017ae/CODE_OF_CONDUCT.md)
+-	**Contributor Guide:** [argo/community/](https://github.com/argoproj/community-contrib-docs/blob/master/argo-cd/developer/contributing.md)
 -	**Chat:** [Argo Slack](https://argoproj.slack.com/)
 -	**License:** [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)
 -	**Legal Requirements:** [Argo CLA](https://github.com/argoproj/argo/tree/master/community#contributing-to-argo)

--- a/content/contributors/projects/_index.md
+++ b/content/contributors/projects/_index.md
@@ -325,7 +325,7 @@ CloudEvents Specification
 *"Open source Kubernetes native workflows, events, CI and CD"* - [https://argoproj.github.io/ ][$Argo overview]
 
 -	**Project Repository:** https://github.com/argoproj/
--	**Contributor Guide:** [argo/community/][(https://github.com/argoproj/argo/tree/master/community#contributing-to-argo\)
+-	**Contributor Guide:** [argo/community/](https://github.com/argoproj/community-contrib-docs/blob/3b76affa356dbc3160b31f9a96ac81dfa49017ae/CODE_OF_CONDUCT.md)
 -	**Chat:** [Argo Slack](https://argoproj.slack.com/)
 -	**License:** [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)
 -	**Legal Requirements:** [Argo CLA](https://github.com/argoproj/argo/tree/master/community#contributing-to-argo)


### PR DESCRIPTION
**Argo Contribution Docs Link Fixed**
Link displayed was not responsive 
The specified address was also broken
Can be confirmed from the screenshot attached
<img width="400" alt="argo" src="https://user-images.githubusercontent.com/63901956/126887982-afd603af-a792-450f-a4ec-ac0f366f8786.png">

Fixed it with the right address below: 
https://github.com/argoproj/community-contrib-docs/blob/3b76affa356dbc3160b31f9a96ac81dfa49017ae/CODE_OF_CONDUCT.md
