### PR TITLE
Add Tinkerbell to the list of sandbox projects

### DIFF
--- a/content/contributors/_index.md
+++ b/content/contributors/_index.md
@@ -82,6 +82,7 @@ The Cloud Native Computing Foundation projects are listed [below](projects/), to
 |                 [Litmus](projects/#litmus)                 |     Chaos Engineering      |        Go        |
 |                 [Meshery](projects/#meshery)               |     Service Mesh           |     Go, React    |
 | [Service Mesh Performance](projects/#service-mesh-performance)|     Service Mesh           |        Go        |
+|            [Tinkerbell](projects/#tinkerbell)              |   Bare Metal Provisioning  |        Go        |
 |            [MetalLB](projects/#metallb)                    |   Bare Metal Load balancer |        Go        |
 
 # TOC


### PR DESCRIPTION
PR https://github.com/cncf/contribute/pull/71 intended to only update
status of projects, but removed Tinkerbell from the list by mistake.

We add it back again now.

cc @Anubhavjoshi040