### PR TITLE
add KubeArmor as sandbox project

### DIFF
--- a/content/contributors/_index.md
+++ b/content/contributors/_index.md
@@ -90,6 +90,7 @@ The Cloud Native Computing Foundation projects are listed [below](projects/), to
 |   [WasmEdge](projects/#wasmedge)   |      Container Runtime         |       C++, Rust      |
 |   [Akri](projects/#akri)   |      IoT, Edge         |       Rust     |
 |[Open Cluster Management](projects/#open-cluster-management)| Multi-Cluster Orchestration|        Go        |
+|            [KubeArmor](projects/#kubearmor)                |       Runtime Security     |      Go, C       |
 
 # TOC
 

--- a/content/contributors/projects/_index.md
+++ b/content/contributors/projects/_index.md
@@ -628,6 +628,16 @@ Sandbox Projects
 -	**Developer List/Forum:** [Open Cluster Management Mailing Lists](https://groups.google.com/g/open-cluster-management)
 -	**License:** [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)
 -	**Legal Requirements:** [DCO](https://developercertificate.org/)
+
+### KubeArmor
+
+*"KubeArmor is a cloud-native runtime security enforcement system that restricts the behavior (such as process execution, file access, and networking operation) of containers and nodes at the system level."* - [KubeArmor](https://github.com/kubearmor/KubeArmor)
+
+-	**Project Repository:** https://github.com/kubearmor/KubeArmor
+-	**Contributor Guide:** [kubearmor/KubeArmor/CONTRIBUTING](https://github.com/kubearmor/KubeArmor/blob/main/CONTRIBUTING.md)
+-	**Chat:** Slack: `##kubearmor-project` in [kubearmor.slack](https://kubearmor.slack.com)
+-	**Developer List/Forum:** [KubeArmor GitHub Discussions](https://github.com/kubearmor/KubeArmor/discussions)
+-	**License:** [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)
 ---
 
 Archived Projects


### PR DESCRIPTION
Add KubeArmor as sandbox project as per [cncf/toc#752](https://github.com/cncf/toc/issues/752)

Signed-off-by: Rahul Jadhav <r@accuknox.com>