### PR TITLE
Move OpenTracing to "archived" in the projects list

### DIFF
--- a/content/contributors/_index.md
+++ b/content/contributors/_index.md
@@ -40,7 +40,6 @@ The Cloud Native Computing Foundation projects are listed [below](projects/), to
 
 |               Project Name               |          Focus           | Primary Language |
 | :--------------------------------------: | :----------------------: | :--------------: |
-|   [OpenTracing](projects/#opentracing)   | Distributed Tracing API  |        Go        |
 |          [gRPC](projects/#grpc)          |  Remote Procedure Call   |        Go        |
 |           [CNI](projects/#cni)           |      Networking API      |                  |
 |        [Notary](projects/#notary)        |         Security         |        Go        |

--- a/content/contributors/projects/_index.md
+++ b/content/contributors/projects/_index.md
@@ -197,17 +197,6 @@ Graduated Projects
 Incubating Projects
 -------------------
 
-### OpenTracing
-
-Vendor-neutral APIs and instrumentation for distributed tracing.
-
--	**Project Repository:** https://github.com/opentracing
--	**Contributor Guide:** [opentracing-contrib/meta](https://github.com/opentracing-contrib/meta#opentracing-contributions)
--	**Chat:** Gitter: [gitter.im/opentracing/public](https://gitter.im/opentracing/public)
--	**Developer Mailing List/Forum:** [OpenTracing Mailing List](https://groups.google.com/forum/#!forum/opentracing)
--	**License:** [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)
--	**Legal Requirements:** None
-
 ### gRPC
 
 *"gRPC is a modern open source high performance RPC framework that can run in any environment. It can efficiently connect services in and across data centers with pluggable support for load balancing, tracing, health checking and authentication. It is also applicable in last mile of distributed computing to connect devices, mobile applications and browsers to backend services."* - [About - grpc.io](https://grpc.io/about/)
@@ -777,6 +766,17 @@ Non-code Projects
 
 Archived Projects
 -----------------
+
+### OpenTracing
+
+Vendor-neutral APIs and instrumentation for distributed tracing.
+
+-	**Project Repository:** https://github.com/opentracing
+-	**Contributor Guide:** [opentracing-contrib/meta](https://github.com/opentracing-contrib/meta#opentracing-contributions)
+-	**Chat:** Gitter: [gitter.im/opentracing/public](https://gitter.im/opentracing/public)
+-	**Developer Mailing List/Forum:** [OpenTracing Mailing List](https://groups.google.com/forum/#!forum/opentracing)
+-	**License:** [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)
+-	**Legal Requirements:** None
 
 ### rkt
 


### PR DESCRIPTION
- I was looking through this list to find interesting projects and I saw OpenTracing, which [there's a blog post](https://www.cncf.io/blog/2022/01/31/cncf-archives-the-opentracing-project/) about being an archived CNCF project (and it's on the CNCF's [archived projects](https://www.cncf.io/archived-projects/) page too. In light of this, move it to the "archived" section along with rkt.
- I am not affiliated with the CNCF or OpenTracing just an interested community observer improving some docs.
- The `contributors/_index` list doesn't have a section for "archived" projects (because contributions are impossible?), so I've just removed the table row completely.