### PR TITLE
Pin node to 12.20.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,7 @@
 [build.environment]
   HUGO_VERSION = "0.79.0"
   HUGO_ENV = "production"
+  NODE_VERSION = "12.20.0"
 
 [context.branch-deploy]
   command = "go run mage.go -v DeployPreview"


### PR DESCRIPTION
This fixes the error when building with postcss on Netlify:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are supported by the default ESM loader
```

See https://github.com/postcss/postcss-cli/issues/404 for more information.
