### PR TITLE
Add CNCF Tag Contributor Strategy chairs to collaborators.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -29,3 +29,9 @@ collaborators:
     # all permissions except admin
   - username: carolynvs
     permission: push
+
+  - username: jberkus
+    permission: push
+    
+  - username: geekygirldawn
+    permission: push


### PR DESCRIPTION
Adding the two TAG-CS chairs, since TAG-CS "owns" the contribute site.


Attn: @carolynvs 