### PR TITLE
Update Knative legal requirements to EasyCLA

### DIFF
--- a/content/contributors/projects.md
+++ b/content/contributors/projects.md
@@ -401,7 +401,7 @@ native workloads"* - [cilium.io](https://cilium.io)
 -   **Contributor Guide:** [Knative contributor guide](https://knative.dev/docs/community/contributing/)
 -   **Chat:** [Knative slack](https://knative.slack.com/)
 -   **License:** [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)
--   **Legal Requirements:** [Google CLA](https://cla.developers.google.com)
+-   **Legal Requirements:** [CNCF CLA](https://github.com/cncf/cla)
 ---
 
 Sandbox Projects


### PR DESCRIPTION
Now that Knative has moved from Google CLA to EasyCLA, that should be reflected on the contributions page.

Signed-off-by: Lance Ball <lball@redhat.com>